### PR TITLE
Ignore blank clippings and clean up Python style

### DIFF
--- a/pyrewood.py
+++ b/pyrewood.py
@@ -58,18 +58,18 @@ clipping_text = 4
 equals_line = 5
 
 
-def remove_chars(str):
+def remove_chars(s):
   # replace colons with a hyphen so "A: B" becomes "A - B"
-  str = re.sub(' *: *', ' - ', str)  
-  str = str.replace('?','')
-  str = str.replace('&','and')
+  s = re.sub(' *: *', ' - ', s)  
+  s = s.replace('?','')
+  s = s.replace('&','and')
   # replace ( ) with a hyphen so "this (text)" becomes "this - text"
-  str = re.sub('\((.+?)\)', r'- \1', str)  
+  s = re.sub('\((.+?)\)', r'- \1', s)  
   # delete filename chars tht are not alphanumeric or ; , _ -
-  str = re.sub('[^a-zA-Z\d\s;,_-]+', '', str)  
+  s = re.sub('[^a-zA-Z\d\s;,_-]+', '', s)  
   # trim off anything that isn't a word at the start & end
-  str = re.sub('^\W+|\W+$', '', str)  
-  return str
+  s = re.sub('^\W+|\W+$', '', s)  
+  return s
 
 # create the output directory
 if not os.path.exists(dirname):
@@ -117,7 +117,7 @@ for x in data:
         outfile = open(path, 'a')
 
   # include metadata (location, time etc.) if desired
-  elif current_line == clipping_info and show_info == True:
+  elif current_line == clipping_info and show_info:
     x = x.replace('- Your Highlight on ','')
     x = x.replace('Added on ','')
     outfile.write("%s\n\n" % x)

--- a/pyrewood.py
+++ b/pyrewood.py
@@ -17,10 +17,24 @@ import os
 # option to include metadata for each clipping
 show_info = False
 
-default_filename = "My Clippings.txt"
+DEFAULT_FILENAME = "My Clippings.txt"
 
 # Firewood will output into a directory with this name 
-dirname = "Kindle Clippings"
+DIRNAME = "Kindle Clippings"
+
+# each clipping always consists of 5 lines:
+# - title line
+# - clipping info/metadata
+# - a blank line
+# - clipping text
+# - a divider made up of equals signs
+
+# so we track the index of the lines we care about, and use MOD to extract the
+# "type" of the line from the absolute line number of the file
+TITLE_LINE = 0
+CLIPPING_INFO = 1
+CLIPPING_TEXT = 3
+MOD = 5
 
 if len(argv) >= 3:
   script, arg1, arg2 = argv
@@ -36,11 +50,11 @@ elif len(argv) == 2:
   script, arg1 = argv
   if arg1 == "-i":
     show_info = True
-    filename = default_filename
+    filename = DEFAULT_FILENAME
   else:
     filename = arg1
 else:
-  filename = default_filename
+  filename = DEFAULT_FILENAME
 
 # check that file exists, otherwise exit
 if not os.path.isfile(filename):
@@ -49,14 +63,6 @@ if not os.path.isfile(filename):
   print "If you've renamed it, enter the new file name like this:"
   print "\tpython pyrewood.py new_file_name.txt"
   sys.exit()
-
-# each clipping always consists of 5 lines
-title_line = 1
-clipping_info = 2
-blank_line = 3
-clipping_text = 4
-equals_line = 5
-
 
 def remove_chars(s):
   # replace colons with a hyphen so "A: B" becomes "A - B"
@@ -72,21 +78,15 @@ def remove_chars(s):
   return s
 
 # create the output directory
-if not os.path.exists(dirname):
-  os.makedirs(dirname)
+if not os.path.exists(DIRNAME):
+  os.makedirs(DIRNAME)
 
-current_line = 1 # line counter
-list_of_titles = [] # list of titles already processed
-list_of_output_files = [] # list of titles already processed
-last_title = ''
+output_files = set() # set of titles already processed
+title = metadata = ''
 
 # open My Clippings.txt and read data in lines
 infile = open(filename, 'r')
-data = infile.readlines()
-
-# for each line
-for x in data:
-
+for line_num, x in enumerate(infile):
   # trim \r\n from line
   x = re.sub('[\r\n]','', x)
   # trim hex bytes at start if they're there
@@ -94,46 +94,36 @@ for x in data:
     x = x[3:]
 
   # if we're at a title line and it doesn't match the last title
-  if current_line == title_line:
-    if x != last_title:
-      # check if we've already seen that title
-      if x not in list_of_titles:
-        # if not, we have a new book - add it to the list
-        list_of_titles.append(x)
-        last_title = x
-        # trim filename-unfriendly chars for outfile name
-        outfile_name = remove_chars(x) + '.txt'
-        # open outfile for writing
-        path = dirname + '/' + outfile_name
-        outfile = open(path, 'w')
-        # add the new filename to the list to display at the end
-        list_of_output_files.append(outfile_name)
-      else:
-        # close last title's outfile
-        outfile.close()
-        # found title match, so reopen old file and append
-        outfile_name = remove_chars(x) + '.txt'
-        path = dirname + '/' + outfile_name
-        outfile = open(path, 'a')
+  if line_num % MOD == TITLE_LINE:
+    title = x
+  elif line_num % MOD == CLIPPING_INFO:
+    # include metadata (location, time etc.) if desired
+    if show_info:
+      metadata = x.replace('- Your Highlight on ','').replace('Added on ','')
+    # otherwise, clear `metadata`
+    else:
+      metadata = ''
+  elif line_num % MOD == CLIPPING_TEXT:
+    # Skip trying to write if we have no body
+    if x == '':
+      continue
 
-  # include metadata (location, time etc.) if desired
-  elif current_line == clipping_info and show_info:
-    x = x.replace('- Your Highlight on ','')
-    x = x.replace('Added on ','')
-    outfile.write("%s\n\n" % x)
+    # trim filename-unfriendly chars for outfile name
+    outfile_name = remove_chars(title) + '.txt'
+    # add to set of output_files
+    output_files.add(outfile_name)
 
-  # the body of the clipping
-  elif current_line == clipping_text:
-    outfile.write("%s\n\n...\n\n" % x)
-
-  current_line = current_line + 1
-  if current_line >= 6:
-    current_line = 1
+    path = DIRNAME + '/' + outfile_name
+    with open(path, 'a') as outfile:
+      if metadata:
+        # write out any necessary metadata
+        outfile.write("%s\n\n" % metadata)
+      # write out the current line (the clippings text)
+      outfile.write("%s\n\n...\n\n" % x)
 
 print "\nExported titles:\n"
-for i in list_of_output_files:
+for i in output_files:
   print "%s" % i
 
-outfile.close()
 infile.close()
 

--- a/pyrewood.py
+++ b/pyrewood.py
@@ -110,11 +110,16 @@ for line_num, x in enumerate(infile):
 
     # trim filename-unfriendly chars for outfile name
     outfile_name = remove_chars(title) + '.txt'
-    # add to set of output_files
-    output_files.add(outfile_name)
+
+    # we want to `append` by default, but if this is the first time we're
+    # seeing this title, we should set the mode to `write`
+    mode = 'a'
+    if outfile_name not in output_files:
+      mode = 'w'
+      output_files.add(outfile_name)
 
     path = DIRNAME + '/' + outfile_name
-    with open(path, 'a') as outfile:
+    with open(path, mode) as outfile:
       if metadata:
         # write out any necessary metadata
         outfile.write("%s\n\n" % metadata)


### PR DESCRIPTION
My "My Clippings.txt" has a handful of empty clippings via unintended Bookmarks, and I wanted to avoid capturing those in the outputted text files.

As I went through, I ended up refactoring a bit of your Python script - I hope you don't mind! A few notes on the changes I made, from cosmetic to more major:
- Using Python `set`s instead of lists, which have built-in uniquing
- Being a little more consistent about only defining constants (`CONSTANT_NAME`) that we'll use (e.g. no more need to track `blank_line = 5`)
- Using `enumerate(infile)` instead of having to manually keep track of a line count
- Using `with open(path, 'w') as outfile` so we don't have to manually close the file (or even think about handling errors!)
- Writing one full clipping out to a file at once, rather than opening a file during iteration `n` through the loop and writing to it a few loops later

Hope you don't mind I made so many changes. Thanks for getting this tool out there, and I hope this pull request is useful!
